### PR TITLE
Fix LabelFile image dimension bug

### DIFF
--- a/labelme/label_file.py
+++ b/labelme/label_file.py
@@ -32,6 +32,8 @@ class LabelFile(object):
         self.shapes = []
         self.imagePath = None
         self.imageData = None
+        self.imageHeight = None
+        self.imageWidth = None
         if filename is not None:
             self.load(filename)
         self.filename = filename
@@ -90,7 +92,7 @@ class LabelFile(object):
                 imageData = self.load_image_file(imagePath)
             flags = data.get("flags") or {}
             imagePath = data["imagePath"]
-            self._check_image_height_and_width(
+            imageHeight, imageWidth = self._check_image_height_and_width(
                 base64.b64encode(imageData).decode("utf-8"),
                 data.get("imageHeight"),
                 data.get("imageWidth"),
@@ -123,6 +125,8 @@ class LabelFile(object):
         self.shapes = shapes
         self.imagePath = imagePath
         self.imageData = imageData
+        self.imageHeight = imageHeight
+        self.imageWidth = imageWidth
         self.filename = filename
         self.otherData = otherData
 
@@ -179,6 +183,8 @@ class LabelFile(object):
             with open(filename, "w") as f:
                 json.dump(data, f, ensure_ascii=False, indent=2)
             self.filename = filename
+            self.imageHeight = imageHeight
+            self.imageWidth = imageWidth
         except Exception as e:
             raise LabelFileError(e)
 

--- a/tests/labelme_tests/utils_tests/test_label_file.py
+++ b/tests/labelme_tests/utils_tests/test_label_file.py
@@ -1,0 +1,34 @@
+import base64
+import json
+import numpy as np
+from pathlib import Path
+import PIL.Image
+
+from labelme.label_file import LabelFile
+
+
+def test_load_corrects_height_width(tmp_path: Path):
+    # create simple image
+    img = np.zeros((10, 20, 3), dtype=np.uint8)
+    img_path = tmp_path / "test.png"
+    PIL.Image.fromarray(img).save(img_path)
+
+    with open(img_path, "rb") as f:
+        img_b64 = base64.b64encode(f.read()).decode("utf-8")
+
+    data = {
+        "version": "5.8.2",
+        "imageData": img_b64,
+        "imagePath": str(img_path.name),
+        "shapes": [],
+        "flags": {},
+        "imageHeight": 1,
+        "imageWidth": 1,
+    }
+    json_path = tmp_path / "test.json"
+    with open(json_path, "w") as f:
+        json.dump(data, f)
+
+    lf = LabelFile(str(json_path))
+    assert lf.imageHeight == 10
+    assert lf.imageWidth == 20


### PR DESCRIPTION
## Summary
- keep track of `imageHeight` and `imageWidth` in `LabelFile`
- correct height/width during load and save
- add regression test for handling mismatched dimensions

## Testing
- `pytest tests/labelme_tests/utils_tests/test_label_file.py tests/labelme_tests/utils_tests/test_image.py tests/labelme_tests/utils_tests/test_shape.py -q`

------
https://chatgpt.com/codex/tasks/task_b_687159fa7b30832086ca4567e1008dce