### PR TITLE
Add Windows automation script for building exe

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,13 @@ pyinstaller labelme/labelme/__main__.py \
   --onedir
 ```
 
+On Windows systems the `build_windows_exe.bat` script automates these
+steps using a virtual environment:
+
+```cmd
+build_windows_exe.bat
+```
+
 ## Improvements by neuraforce
 
 - Track modified files and color them blue

--- a/build_windows_exe.bat
+++ b/build_windows_exe.bat
@@ -1,0 +1,32 @@
+@echo off
+setlocal
+
+REM Create a virtual environment if it does not exist
+if not exist venv (
+    python -m venv venv
+)
+
+call venv\Scripts\activate.bat
+
+REM Upgrade pip and install required packages
+pip install --upgrade pip
+pip install pyinstaller
+pip install .
+
+for /f %%i in ('python -c "import os, osam; print(os.path.dirname(osam.__file__))"') do set OSAM_PATH=%%i
+set LABELME_PATH=%cd%\labelme
+
+pyinstaller labelme\labelme\__main__.py ^
+  --name=Labelme ^
+  --windowed ^
+  --noconfirm ^
+  --specpath=build ^
+  --add-data=%OSAM_PATH%\_models\yoloworld\clip\bpe_simple_vocab_16e6.txt.gz;osam\_models\yoloworld\clip ^
+  --add-data=%LABELME_PATH%\config\default_config.yaml;labelme\config ^
+  --add-data=%LABELME_PATH%\icons\*;labelme\icons ^
+  --add-data=%LABELME_PATH%\translate\*;translate ^
+  --icon=%LABELME_PATH%\icons\icon.png ^
+  --onedir
+
+call deactivate
+endlocal


### PR DESCRIPTION
## Summary
- add `build_windows_exe.bat` for fully automatic PyInstaller build on Windows
- document the new script in the README

## Testing
- `pip install .`
- `pytest -q tests` *(fails: ModuleNotFoundError: No module named 'pytestqt')*

------
https://chatgpt.com/codex/tasks/task_b_68715f87897c8320bab53afeb5083218