### PR TITLE
Optimize IoU filter caching

### DIFF
--- a/labelme/app.py
+++ b/labelme/app.py
@@ -144,6 +144,8 @@ class MainWindow(QtWidgets.QMainWindow):
         self._noSelectionSlot = False
 
         self._copied_shapes = None
+        # cache label file contents to avoid re-reading on filtering
+        self._label_cache = {}
 
         # Main widgets and related state.
         self.labelDialog = LabelDialog(
@@ -1364,10 +1366,13 @@ class MainWindow(QtWidgets.QMainWindow):
             if not QtCore.QFile.exists(label_file):
                 continue
             try:
-                lf = LabelFile(label_file)
+                shapes = self._label_cache.get(label_file)
+                if shapes is None:
+                    shapes = LabelFile.load_shapes(label_file)
+                    self._label_cache[label_file] = shapes
             except Exception:
                 continue
-            if _has_overlap(lf.shapes, threshold):
+            if _has_overlap(shapes, threshold):
                 matched.append(filename)
             QtWidgets.QApplication.processEvents()
         progress.setValue(self.fileListWidget.count())

--- a/labelme/label_file.py
+++ b/labelme/label_file.py
@@ -191,3 +191,22 @@ class LabelFile(object):
     @staticmethod
     def is_label_file(filename):
         return osp.splitext(filename)[1].lower() == LabelFile.suffix
+
+    @staticmethod
+    def load_shapes(filename):
+        """Load only the shapes from *filename* without reading image data."""
+        try:
+            with io.open(filename, "r", encoding="utf-8") as f:
+                data = json.load(f)
+            return [
+                dict(
+                    label=s.get("label"),
+                    points=s.get("points", []),
+                    group_id=s.get("group_id"),
+                    shape_type=s.get("shape_type", "polygon"),
+                    flags=s.get("flags", {}),
+                )
+                for s in data.get("shapes", [])
+            ]
+        except Exception as e:
+            raise LabelFileError(e)

--- a/tests/labelme_tests/utils_tests/test_label_file.py
+++ b/tests/labelme_tests/utils_tests/test_label_file.py
@@ -32,3 +32,22 @@ def test_load_corrects_height_width(tmp_path: Path):
     lf = LabelFile(str(json_path))
     assert lf.imageHeight == 10
     assert lf.imageWidth == 20
+
+
+def test_load_shapes(tmp_path: Path):
+    data = {
+        "shapes": [
+            {
+                "label": "cat",
+                "points": [[0, 0], [1, 1]],
+                "shape_type": "rectangle",
+            }
+        ]
+    }
+    json_path = tmp_path / "ann.json"
+    with open(json_path, "w") as f:
+        json.dump(data, f)
+
+    shapes = LabelFile.load_shapes(str(json_path))
+    assert shapes[0]["label"] == "cat"
+    assert shapes[0]["points"] == [[0, 0], [1, 1]]


### PR DESCRIPTION
## Summary
- add `load_shapes` helper that parses annotation JSON without images
- cache label files while filtering to avoid repeated disk I/O
- test `load_shapes`

## Testing
- `QT_QPA_PLATFORM=offscreen pytest tests/labelme_tests/utils_tests/test_label_file.py -q`
- `pytest -q` *(fails: Fatal Python error: Aborted)*

------
https://chatgpt.com/codex/tasks/task_b_6874a8add89883208347a0790d2fe218