### PR TITLE
Enhance filtering and UI interactions

### DIFF
--- a/labelme/widgets/class_count_widget.py
+++ b/labelme/widgets/class_count_widget.py
@@ -10,6 +10,7 @@ class ClassCountWidget(QtWidgets.QListWidget):
         super().__init__(parent)
         self.itemDoubleClicked.connect(self._emit_label)
         self.setMinimumWidth(120)
+        self.setMaximumHeight(60)
 
     def _emit_label(self, item: QtWidgets.QListWidgetItem) -> None:
         label = item.data(QtCore.Qt.UserRole)


### PR DESCRIPTION
## Summary
- keep class count widget height compact
- allow clearing IoU filter
- update file list title with item count
- improve label filtering logic
- open label editor when double clicking a shape
- refresh class counts on file change

## Testing
- `pip install -e .[dev]`
- `pip install pytest-qt`
- `pytest -q` *(fails: Aborted due to Qt display issue)*

------
https://chatgpt.com/codex/tasks/task_b_68751d9ad6c483209531a5e3c823419f