### PR TITLE
Fix label count computation when cache is modified

### DIFF
--- a/labelme/app.py
+++ b/labelme/app.py
@@ -1590,7 +1590,9 @@ class MainWindow(QtWidgets.QMainWindow):
 
     def _compute_label_counts(self) -> dict[str, int]:
         counts: dict[str, int] = {}
-        for shapes in self._label_cache.values():
+        # Make a copy of the cached shapes to prevent 'dictionary changed size'
+        # errors when the cache is mutated from background threads.
+        for shapes in list(self._label_cache.values()):
             for s in shapes:
                 label = s.get("label")
                 if not label:


### PR DESCRIPTION
## Summary
- prevent `RuntimeError: dictionary changed size during iteration` when computing label counts

## Testing
- `pytest -q` *(fails: Aborted)*

------
https://chatgpt.com/codex/tasks/task_b_687533a127e083208b004db93a73026d