### PR TITLE
Fix class count filtering

### DIFF
--- a/labelme/widgets/ai_prompt_widget.py
+++ b/labelme/widgets/ai_prompt_widget.py
@@ -114,3 +114,6 @@ class _IouThresholdWidget(QtWidgets.QWidget):
 
     def get_value(self) -> float:
         return self._threshold_widget.value()
+
+    def set_value(self, value: float) -> None:
+        self._threshold_widget.setValue(value)

--- a/labelme/widgets/class_count_widget.py
+++ b/labelme/widgets/class_count_widget.py
@@ -14,6 +14,7 @@ class ClassCountWidget(QtWidgets.QListWidget):
         super().__init__(parent)
         self.itemDoubleClicked.connect(self._emit_label)
         self.setMinimumWidth(120)
+        self._selected_label: str | None = None
         # allow the dock to be resized vertically and provide a larger default
         # height via ``sizeHint``.
 
@@ -49,3 +50,15 @@ class ClassCountWidget(QtWidgets.QListWidget):
                 item.setForeground(QtGui.QColor(r, g, b))
             item.setFlags(QtCore.Qt.ItemIsEnabled | QtCore.Qt.ItemIsSelectable)
             self.addItem(item)
+        # reapply selection formatting after repopulating
+        self.set_selected_label(self._selected_label)
+
+    def set_selected_label(self, label: str | None) -> None:
+        """Highlight the currently selected label."""
+        self._selected_label = label
+        for i in range(self.count()):
+            item = self.item(i)
+            item_label = item.data(QtCore.Qt.UserRole)
+            font = item.font()
+            font.setBold(item_label == label)
+            item.setFont(font)


### PR DESCRIPTION
## Summary
- fix filtering when double-clicking class in Class Counts dock
- clear all filters when Clear is pressed
- bold the currently selected class in the counts panel

## Testing
- `ruff check labelme/app.py labelme/widgets/ai_prompt_widget.py labelme/widgets/class_count_widget.py`
- `pytest -q` *(fails: AttributeError: module 'pydantic' has no attribute 'field_validator')*

------
https://chatgpt.com/codex/tasks/task_b_6875655a6bcc832099cbcdecbd9cccd7