### PR TITLE
Update cache on save

### DIFF
--- a/labelme/app.py
+++ b/labelme/app.py
@@ -1742,6 +1742,9 @@ class MainWindow(QtWidgets.QMainWindow):
 
             # disable allows next and previous image to proceed
             # self.filename = filename
+            # update cache and class counts after saving
+            self._label_cache[filename] = shapes
+            self._update_class_counts()
             return True
         except LabelFileError as e:
             self.errorMessage(
@@ -2340,7 +2343,7 @@ class MainWindow(QtWidgets.QMainWindow):
         if filename and self.saveLabels(filename):
             self.addRecentFile(filename)
             self.setClean()
-            self._label_cache.pop(filename, None)
+
 
     def closeFile(self, _value=False):
         if not self.mayContinue():


### PR DESCRIPTION
## Summary
- update cache after saving annotations
- refresh class counts once cache is updated

## Testing
- `QT_QPA_PLATFORM=offscreen pytest tests/labelme_tests/utils_tests/test_label_file.py -q`
- `QT_QPA_PLATFORM=offscreen pytest tests/labelme_tests/utils_tests/test_shape.py -q`


------
https://chatgpt.com/codex/tasks/task_b_6875b4f05c3083209b7cba2fd7ea3142