### PR TITLE
Add detector settings to config

### DIFF
--- a/labelme/__main__.py
+++ b/labelme/__main__.py
@@ -186,6 +186,20 @@ def main():
         help="path to an Ultralytics YOLO model (.pt)",
         default=argparse.SUPPRESS,
     )
+    parser.add_argument(
+        "--detector-conf",
+        dest="detector_conf",
+        type=float,
+        help="object detector confidence threshold",
+        default=argparse.SUPPRESS,
+    )
+    parser.add_argument(
+        "--detector-iou",
+        dest="detector_iou",
+        type=float,
+        help="object detector IoU threshold",
+        default=argparse.SUPPRESS,
+    )
     args = parser.parse_args()
 
     if args.version:
@@ -223,8 +237,16 @@ def main():
     filename = config_from_args.pop("filename")
     output = config_from_args.pop("output")
     detector_model = config_from_args.pop("detector", None)
+    detector_conf = config_from_args.pop("detector_conf", None)
+    detector_iou = config_from_args.pop("detector_iou", None)
     config_file_or_yaml = config_from_args.pop("config")
     config = get_config(config_file_or_yaml, config_from_args)
+    if detector_model is not None:
+        config["detector_model"] = detector_model
+    if detector_conf is not None:
+        config["detector_conf_threshold"] = detector_conf
+    if detector_iou is not None:
+        config["detector_iou_threshold"] = detector_iou
 
     if not config["labels"] and config["validate_label"]:
         logger.error(
@@ -256,7 +278,7 @@ def main():
         filename=filename,
         output_file=output_file,
         output_dir=output_dir,
-        detector=detector_model,
+        detector=config.get("detector_model"),
     )
 
     if reset_config:

--- a/labelme/app.py
+++ b/labelme/app.py
@@ -1256,7 +1256,12 @@ class MainWindow(QtWidgets.QMainWindow):
             self._detector = YOLO(self._detector_model_path)
 
         img = utils.img_qt_to_arr(self.image)[:, :, :3]
-        results = self._detector.predict(img, conf=0.5, iou=0.35, verbose=False)
+        results = self._detector.predict(
+            img,
+            conf=self._config["detector_conf_threshold"],
+            iou=self._config["detector_iou_threshold"],
+            verbose=False,
+        )
         res = results[0]
         boxes = res.boxes.xyxy.cpu().numpy()
         classes = res.boxes.cls.cpu().numpy().astype(int)

--- a/labelme/config/default_config.yaml
+++ b/labelme/config/default_config.yaml
@@ -33,6 +33,10 @@ shape:
 ai:
   default: 'Sam2 (balanced)'
 
+detector_model: null
+detector_conf_threshold: 0.5
+detector_iou_threshold: 0.35
+
 # main
 flag_dock:
   show: true


### PR DESCRIPTION
## Summary
- add detector options to default config
- expose `--detector-conf` and `--detector-iou` CLI options
- respect detector thresholds from config in detection routine

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pytestqt')*

------
https://chatgpt.com/codex/tasks/task_b_687a6d311c30832082b7160db6705340