### PR TITLE
Add YOLO dependency extras

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,10 @@ steps using a virtual environment:
 build_windows_exe.bat
 ```
 
+If you need the YOLO detection feature in the executable, make sure that
+`ultralytics` and `onnxruntime` are installed. The bundled build script installs
+them automatically via `pip install .[yolo]`.
+
 ## Improvements by neuraforce
 
 - Track modified files and color them blue
@@ -158,6 +162,7 @@ build_windows_exe.bat
 - Add functionality to reload folder and check for new files
 - Add functionality to automatically select next unlabelled item
 - Menu bar: Create rectangles by default (not polygons)
+- Optional object detection via Ultralytics YOLO (install with `pip install labelme[yolo]`)
 
 ## Bugfixes by neuraforce
 

--- a/build_windows_exe.bat
+++ b/build_windows_exe.bat
@@ -11,7 +11,8 @@ call venv\Scripts\activate.bat
 REM Upgrade pip and install required packages
 pip install --upgrade pip
 pip install pyinstaller
-pip install .
+REM Install labelme with optional YOLO dependencies
+pip install .[yolo]
 
 for /f %%i in ('python -c "import os, osam; print(os.path.dirname(osam.__file__))"') do set OSAM_PATH=%%i
 set LABELME_PATH=%cd%\labelme
@@ -28,9 +29,11 @@ pyinstaller %LABELME_PATH%\__main__.py ^
   --hidden-import=labelme.app ^
   --hidden-import=osam ^
   --hidden-import=onnxruntime ^
+  --hidden-import=ultralytics ^
   --collect-all labelme ^
   --collect-all osam ^
   --collect-all onnxruntime ^
+  --collect-all ultralytics ^
   --add-binary=%ONNX_PATH%\capi\*.dll;. ^
   --add-data=%OSAM_PATH%\_models\yoloworld\clip\bpe_simple_vocab_16e6.txt.gz;osam\_models\yoloworld\clip ^
   --add-data=%LABELME_PATH%;labelme ^

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,13 @@ dependencies = [
   "scikit-image",
 ]
 
+[project.optional-dependencies]
+# Packages required for the YOLO object detection feature.
+yolo = [
+  "ultralytics",
+  "onnxruntime",
+]
+
 [tool.hatch.metadata.hooks.fancy-pypi-readme]
 content-type = "text/markdown"
 fragments = [{ path = "README.md" }]


### PR DESCRIPTION
## Summary
- document YOLO optional install for object detection
- add [yolo] optional dependency with ultralytics and onnxruntime
- bundle YOLO in Windows build script

## Testing
- `pip install .`
- `pytest -q` *(fails: Aborted when initializing PyQt5)*

------
https://chatgpt.com/codex/tasks/task_b_687a868835308320b9c5d3dffe836ffb