### PR TITLE
Improve YOLO preprocessing and add multi-scale detection

### DIFF
--- a/labelme/config/default_config.yaml
+++ b/labelme/config/default_config.yaml
@@ -36,6 +36,11 @@ ai:
 detector_model: null
 detector_conf_threshold: 0.5
 detector_iou_threshold: 0.35
+detector_scales:
+  - 0.5
+  - 1.0
+  - 1.5
+  - 2.0
 
 # main
 flag_dock:


### PR DESCRIPTION
## Summary
- import PIL to resize images
- implement simple NMS helper
- convert Qt image to RGB before running YOLO
- run detection over multiple image scales and merge using NMS
- expose `detector_scales` in default config
- improve NMS to work per-class
- add 4 recommended detector scales

## Testing
- `python -m py_compile labelme/app.py`
- `make test` *(fails: Fatal Python error: Aborted)*


------
https://chatgpt.com/codex/tasks/task_b_687f4c0d13d88320b6f8152513e59532