### PR TITLE
Add toolbar controls for shape order

### DIFF
--- a/labelme/app.py
+++ b/labelme/app.py
@@ -567,6 +567,22 @@ class MainWindow(QtWidgets.QMainWindow):
             self.tr("Create a duplicate of the selected polygons"),
             enabled=False,
         )
+        moveUp = action(
+            self.tr("Move up"),
+            self.moveLabelUp,
+            None,
+            "prev",
+            self.tr("Move selected shape up"),
+            enabled=False,
+        )
+        moveDown = action(
+            self.tr("Move down"),
+            self.moveLabelDown,
+            None,
+            "next",
+            self.tr("Move selected shape down"),
+            enabled=False,
+        )
         copy = action(
             self.tr("Copy Polygons"),
             self.copySelectedShape,
@@ -782,6 +798,8 @@ class MainWindow(QtWidgets.QMainWindow):
             delete=delete,
             edit=edit,
             duplicate=duplicate,
+            moveUp=moveUp,
+            moveDown=moveDown,
             copy=copy,
             paste=paste,
             undoLastPoint=undoLastPoint,
@@ -815,6 +833,8 @@ class MainWindow(QtWidgets.QMainWindow):
             editMenu=(
                 edit,
                 duplicate,
+                moveUp,
+                moveDown,
                 copy,
                 paste,
                 delete,
@@ -996,6 +1016,8 @@ class MainWindow(QtWidgets.QMainWindow):
                 createRectangleMode,
                 editMode,
                 duplicate,
+                moveUp,
+                moveDown,
                 delete,
                 undo,
                 brightnessContrast,
@@ -1752,6 +1774,8 @@ class MainWindow(QtWidgets.QMainWindow):
         self.actions.duplicate.setEnabled(n_selected)  # type: ignore[attr-defined]
         self.actions.copy.setEnabled(n_selected)  # type: ignore[attr-defined]
         self.actions.edit.setEnabled(n_selected)  # type: ignore[attr-defined]
+        self.actions.moveUp.setEnabled(n_selected)  # type: ignore[attr-defined]
+        self.actions.moveDown.setEnabled(n_selected)  # type: ignore[attr-defined]
 
     def addLabel(self, shape):
         if shape.group_id is None:
@@ -2691,6 +2715,14 @@ class MainWindow(QtWidgets.QMainWindow):
     def moveShape(self):
         self.canvas.endMove(copy=False)
         self.setDirty()
+
+    def moveLabelUp(self) -> None:
+        self.labelList.moveSelectedRowsUp()
+        self.labelOrderChanged()
+
+    def moveLabelDown(self) -> None:
+        self.labelList.moveSelectedRowsDown()
+        self.labelOrderChanged()
 
     def openDirDialog(self, _value=False, dirpath=None):
         if not self.mayContinue():

--- a/labelme/widgets/label_list_widget.py
+++ b/labelme/widgets/label_list_widget.py
@@ -181,3 +181,24 @@ class LabelListWidget(QtWidgets.QListView):
 
     def clear(self):
         self._model.clear()  # type: ignore[union-attr]
+
+    def moveSelectedRowsUp(self) -> None:
+        indexes = sorted(self.selectedIndexes(), key=lambda i: i.row())
+        for index in indexes:
+            row = index.row()
+            if row == 0:
+                continue
+            self._model.insertRow(row - 1, self._model.takeRow(row))
+        if indexes:
+            self.itemDropped.emit()
+
+    def moveSelectedRowsDown(self) -> None:
+        indexes = sorted(self.selectedIndexes(), key=lambda i: i.row(), reverse=True)
+        row_count = self._model.rowCount()
+        for index in indexes:
+            row = index.row()
+            if row >= row_count - 1:
+                continue
+            self._model.insertRow(row + 1, self._model.takeRow(row))
+        if indexes:
+            self.itemDropped.emit()


### PR DESCRIPTION
## Summary
- make label list widget able to move selected rows up or down
- expose toolbar buttons `Move up` and `Move down` to change shape order
- enable new actions only when a shape is selected

## Testing
- `ruff check`
- `pytest -k "not gui" -q`

------
https://chatgpt.com/codex/tasks/task_b_68835f2d01a08320ba3b19ce04291f2b