### PR TITLE
Fix color shift when rotating images

### DIFF
--- a/labelme/app.py
+++ b/labelme/app.py
@@ -2177,7 +2177,11 @@ class MainWindow(QtWidgets.QMainWindow):
         if self.image.isNull():
             return
         w, h = self.image.width(), self.image.height()
-        img_arr = utils.img_qt_to_arr(self.image)
+        # Qt's internal image format may use BGR channel order. Convert to
+        # RGB before extracting the numpy array to prevent channel swapping
+        # when the image is rotated and saved back.
+        image = self.image.convertToFormat(QtGui.QImage.Format_RGB888)
+        img_arr = utils.img_qt_to_arr(image)
         k = -1 if clockwise else 1
         img_arr = np.rot90(img_arr, k)
         self.imageData = utils.img_arr_to_data(img_arr)

--- a/tests/labelme_tests/test_rotate_image.py
+++ b/tests/labelme_tests/test_rotate_image.py
@@ -1,0 +1,41 @@
+import os
+import sys
+import types
+from PyQt5 import QtGui, QtWidgets
+
+# Ensure the repository root is on the path so that "import labelme" works
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
+import labelme.app
+import labelme.utils
+
+
+def test_rotate_image_preserves_color(tmp_path):
+    # ensure headless operation
+    os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+    app = QtWidgets.QApplication.instance() or QtWidgets.QApplication([])
+    # create a simple image with known color
+    image = QtGui.QImage(1, 1, QtGui.QImage.Format_ARGB32)
+    image.setPixelColor(0, 0, QtGui.QColor(10, 20, 30, 255))
+
+    # stub MainWindow attributes needed for rotateImage
+    dummy = types.SimpleNamespace(
+        image=image,
+        imageData=b"",
+        labelList=[],
+        canvas=types.SimpleNamespace(
+            loadPixmap=lambda *args, **kwargs: None,
+            storeShapes=lambda *args, **kwargs: None,
+        ),
+        imagePath=str(tmp_path / "image.png"),
+        setDirty=lambda: None,
+        saveFile=lambda: None,
+        paintCanvas=lambda: None,
+    )
+
+    # rotate clockwise
+    labelme.app.MainWindow.rotateImage(dummy, clockwise=True)
+
+    arr = labelme.utils.img_qt_to_arr(
+        dummy.image.convertToFormat(QtGui.QImage.Format_RGB888)
+    )
+    assert arr[0, 0, :3].tolist() == [10, 20, 30]


### PR DESCRIPTION
## Summary
- Preserve RGB ordering by converting QImage to RGB888 before rotation
- Add regression test ensuring rotated images retain original colors

## Testing
- `pytest tests/labelme_tests/test_rotate_image.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'labelme')*


------
https://chatgpt.com/codex/tasks/task_b_68af4b7258bc8320ad49573322c4f9e1