### PR TITLE
feat: allow renaming current file with F2

### DIFF
--- a/labelme/config/default_config.yaml
+++ b/labelme/config/default_config.yaml
@@ -106,6 +106,7 @@ shortcuts:
   save_as: Ctrl+Shift+S
   save_to: null
   delete_file: Ctrl+Delete
+  rename_file: F2
 
   open_next: [D, Ctrl+Shift+D]
   open_next_blank: [B, Ctrl+Shift+B]


### PR DESCRIPTION
## Summary
- add F2 shortcut to rename current image
- rename associated .json/.txt/.nfmeta files when image name changes

## Testing
- `pytest` *(fails: No module named 'PyQt5')*

------
https://chatgpt.com/codex/tasks/task_b_68af4e1d449c83209dcc54040623c034