### PR TITLE
Handle missing rename_file shortcut

### DIFF
--- a/labelme/app.py
+++ b/labelme/app.py
@@ -417,7 +417,7 @@ class MainWindow(QtWidgets.QMainWindow):
         renameFile = action(
             self.tr("&Rename File"),
             self.renameFile,
-            shortcuts["rename_file"],
+            shortcuts.get("rename_file", "F2"),
             "edit",
             self.tr("Rename current label file and image"),
             enabled=True,


### PR DESCRIPTION
## Summary
- Avoid KeyError when `rename_file` shortcut is missing in user config by defaulting to F2

## Testing
- `uv run ruff format labelme/app.py`
- `uv run ruff check labelme/app.py`
- `make test` *(fails: ImportError: libGL.so.1: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_b_68af511e89808320a4d435f4c278f8ee