### PR TITLE
Fix rotation for images with padded scanlines

### DIFF
--- a/labelme/utils/image.py
+++ b/labelme/utils/image.py
@@ -63,8 +63,10 @@ def img_data_to_png_data(img_data):
 
 def img_qt_to_arr(img_qt):
     w, h, d = img_qt.size().width(), img_qt.size().height(), img_qt.depth()
-    bytes_ = img_qt.bits().asstring(w * h * d // 8)
-    img_arr = np.frombuffer(bytes_, dtype=np.uint8).reshape((h, w, d // 8))
+    bytes_per_line = img_qt.bytesPerLine()
+    bytes_ = img_qt.bits().asstring(bytes_per_line * h)
+    img_arr = np.frombuffer(bytes_, dtype=np.uint8).reshape((h, bytes_per_line))
+    img_arr = img_arr[:, : w * d // 8].reshape((h, w, d // 8))
     return img_arr
 
 

--- a/tests/labelme_tests/test_rotate_image.py
+++ b/tests/labelme_tests/test_rotate_image.py
@@ -13,9 +13,10 @@ def test_rotate_image_preserves_color(tmp_path):
     # ensure headless operation
     os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
     app = QtWidgets.QApplication.instance() or QtWidgets.QApplication([])
-    # create a simple image with known color
-    image = QtGui.QImage(1, 1, QtGui.QImage.Format_ARGB32)
+    # create a simple image with known colors and non-4-byte-aligned width
+    image = QtGui.QImage(1, 2, QtGui.QImage.Format_ARGB32)
     image.setPixelColor(0, 0, QtGui.QColor(10, 20, 30, 255))
+    image.setPixelColor(0, 1, QtGui.QColor(40, 50, 60, 255))
 
     # stub MainWindow attributes needed for rotateImage
     dummy = types.SimpleNamespace(
@@ -38,4 +39,6 @@ def test_rotate_image_preserves_color(tmp_path):
     arr = labelme.utils.img_qt_to_arr(
         dummy.image.convertToFormat(QtGui.QImage.Format_RGB888)
     )
-    assert arr[0, 0, :3].tolist() == [10, 20, 30]
+    assert arr.shape == (1, 2, 3)
+    assert arr[0, 0, :3].tolist() == [40, 50, 60]
+    assert arr[0, 1, :3].tolist() == [10, 20, 30]


### PR DESCRIPTION
## Summary
- handle QImage scanline stride when converting to numpy
- test rotation preserves color for images with padded rows

## Testing
- `pytest tests/labelme_tests/test_rotate_image.py::test_rotate_image_preserves_color -q`

------
https://chatgpt.com/codex/tasks/task_b_68af561d9db8832096a1f04275bc67b0